### PR TITLE
upgrade to v0.10.0

### DIFF
--- a/lib/version.sh
+++ b/lib/version.sh
@@ -1,4 +1,4 @@
 #! /usr/bin/env bash
 # (c) Konstantin Riege
 
-version=0.9.0
+version=0.10.0

--- a/scripts/rippchen.sh
+++ b/scripts/rippchen.sh
@@ -253,13 +253,13 @@ elif [[ $ridx ]]; then
 	[[ ${#ridx[@]} -eq ${#tidx[@]} ]] || false
 fi
 
-if [[ $FASTQ1 ]] && ${RRBS:=false}; then
-	BASHBONE_ERROR="rrbs data analysis requires adapter sequence input"
-	[[ ! $ADAPTER1 ]] && false
-fi
+# if [[ $FASTQ1 ]] && ${RRBS:=false}; then
+# 	BASHBONE_ERROR="rrbs data analysis requires adapter sequence input"
+# 	[[ ! $ADAPTER1 ]] && false
+# fi
 
-if [[ ! $FASTQ2 ]]; then
-	nofsel=true;
+if [[ $FASTQ1 ]] && [[ ! $FASTQ2 ]]; then
+	nofsel=true
 fi
 
 if [[ $FASTQ3 ]]; then


### PR DESCRIPTION
- UMI based deduplication for RRBS data fixed
- devel option `frmd` allows to skip UMI deduplication on fastq level (in order to run salmon)
- due to bashbone upgrade to [v1.4.0](https://github.com/Hoffmann-Lab/bashbone/releases/tag/v1.4.0)
  - revised error bubbling and locking
  - speedups